### PR TITLE
Add descending order to getAllUsers query

### DIFF
--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -878,6 +878,7 @@ export const getAllUsers = async (
       ...filters,
       Query.limit(limit),
       Query.offset(offset),
+      Query.orderDesc
     ]);
 
     return {


### PR DESCRIPTION
Enhance the `getAllUsers` query to support descending order for results.